### PR TITLE
including covR call in github action for coverage generation and upload

### DIFF
--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -72,6 +72,7 @@ jobs:
         run: |
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
+          remotes::install_cran("covr")
         shell: Rscript {0}
 
       - name: Session info
@@ -81,7 +82,11 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
-      - name: Check
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}
+
+      - name: R CMD Check
         env:
           _R_CHECK_CRAN_INCOMING_: false
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 ![R-CMD-check](https://github.com/Urban-Analytics/rampuaR/workflows/R-CMD-check/badge.svg)
+[![codecov](https://codecov.io/gh/Urban-Analytics/rampuaR/branch/master/graph/badge.svg)](https://codecov.io/gh/Urban-Analytics/rampuaR)
 # rampuaR
 R package for RAMP-UA work


### PR DESCRIPTION
This PR includes 1 change:

- adding in automated coverage reporting for PR to master and pushes to master included in the github action

Coverage tests allow us to see how much of our code base is covered by a test and is a nice way to make sure we're testing as much of our code as possible. I've added this workflow into the existing testing action and coverage reports are then uploaded to https://codecov.io/gh/Urban-Analytics/rampuaR