### PR TITLE
adding weekly builds

### DIFF
--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -8,7 +8,9 @@ on:
   pull_request:
     branches:
       - master
-
+  schedule:
+    cron: '30 8 * * MON'
+    
 name: R-CMD-check
 
 jobs:

--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -9,8 +9,8 @@ on:
     branches:
       - master
   schedule:
-    cron: '30 8 * * MON'
-    
+    - cron: '30 8 * * MON'
+
 name: R-CMD-check
 
 jobs:


### PR DESCRIPTION
This repository is now quite stable, so i'm going to add a weekly build schedule. This will run the Github actions at 8:30AM every monday as a way to check the package installs correctly and there are no dependency issues.